### PR TITLE
Port to Yocto 2.1

### DIFF
--- a/classes/flatpak-image.bbclass
+++ b/classes/flatpak-image.bbclass
@@ -6,7 +6,7 @@ IMAGE_FEATURES[validitems] += " \
 FEATURE_PACKAGES_flatpak = " \
     packagegroup-flatpak \
     ${@'flatpak-predefined-repos' \
-         if d.getVar('FLATPAK_APP_REPOS') else ''} \
+         if d.getVar('FLATPAK_APP_REPOS', False) else ''} \
 "
 
 inherit flatpak-repo

--- a/classes/flatpak-repo.bbclass
+++ b/classes/flatpak-repo.bbclass
@@ -25,12 +25,12 @@ IOTQA_EXTRA_BUILDDATA += " \
 #
 
 do_flatpakrepo () {
-   IMAGE_BASENAME="${@d.getVar('IMAGE_BASENAME')}"
-   FLATPAK_IMAGE_PATTERN="${@d.getVar('FLATPAK_IMAGE_PATTERN')}"
+   IMAGE_BASENAME="${@d.getVar('IMAGE_BASENAME', False)}"
+   FLATPAK_IMAGE_PATTERN="${@d.getVar('FLATPAK_IMAGE_PATTERN', False)}"
 
    echo "Flatpak repository population:"
    echo "  * IMAGE_BASENAME: $IMAGE_BASENAME"
-   echo "  * IMAGE_NAME:     ${@d.getVar('IMAGE_NAME')}"
+   echo "  * IMAGE_NAME:     ${@d.getVar('IMAGE_NAME', False)}"
 
    # Bail out if this looks like an initramfs image.
    case $IMAGE_BASENAME in
@@ -58,18 +58,18 @@ do_flatpakrepo () {
        *)                 FLATPAK_RUNTIME=runtime;;
    esac
 
-   FLATPAKBASE="${@d.getVar('FLATPAKBASE')}"
-   FLATPAK_TOPDIR="${@d.getVar('FLATPAK_TOPDIR')}"
-   FLATPAK_TMPDIR="${@d.getVar('FLATPAK_TMPDIR')}"
-   FLATPAK_ROOTFS="${@d.getVar('FLATPAK_ROOTFS')}"
-   FLATPAK_ARCH="${@d.getVar('FLATPAK_ARCH')}"
-   FLATPAK_GPGDIR="${@d.getVar('FLATPAK_GPGDIR')}"
-   FLATPAK_GPGID="${@d.getVar('FLATPAK_GPGID')}"
-   FLATPAK_REPO="${@d.getVar('FLATPAK_REPO')}"
-   FLATPAK_DISTRO="${@d.getVar('FLATPAK_DISTRO')}"
-   FLATPAK_RUNTIME_IMAGE="${@d.getVar('FLATPAK_RUNTIME_IMAGE')}"
-   FLATPAK_CURRENT="${@d.getVar('FLATPAK_CURRENT')}"
-   FLATPAK_VERSION="${@d.getVar('FLATPAK_VERSION')}"
+   FLATPAKBASE="${@d.getVar('FLATPAKBASE', False)}"
+   FLATPAK_TOPDIR="${@d.getVar('FLATPAK_TOPDIR', False)}"
+   FLATPAK_TMPDIR="${@d.getVar('FLATPAK_TMPDIR', False)}"
+   FLATPAK_ROOTFS="${@d.getVar('FLATPAK_ROOTFS', False)}"
+   FLATPAK_ARCH="${@d.getVar('FLATPAK_ARCH', False)}"
+   FLATPAK_GPGDIR="${@d.getVar('FLATPAK_GPGDIR', False)}"
+   FLATPAK_GPGID="${@d.getVar('FLATPAK_GPGID', False)}"
+   FLATPAK_REPO="${@d.getVar('FLATPAK_REPO', False)}"
+   FLATPAK_DISTRO="${@d.getVar('FLATPAK_DISTRO', False)}"
+   FLATPAK_RUNTIME_IMAGE="${@d.getVar('FLATPAK_RUNTIME_IMAGE', False)}"
+   FLATPAK_CURRENT="${@d.getVar('FLATPAK_CURRENT', False)}"
+   FLATPAK_VERSION="${@d.getVar('FLATPAK_VERSION', False)}"
 
    VERSION=$(cat $FLATPAK_ROOTFS/etc/version)
 
@@ -129,7 +129,7 @@ do_flatpakrepo[vardeps] += " \
 # exporting image to archive-z2 repository
 #
 do_flatpakexport () {
-   FLATPAK_EXPORT="${@d.getVar('FLATPAK_EXPORT')}"
+   FLATPAK_EXPORT="${@d.getVar('FLATPAK_EXPORT', False)}"
 
    # Bail out early if no export repository is defined.
    if [ -z "$FLATPAK_EXPORT" ]; then
@@ -137,12 +137,12 @@ do_flatpakexport () {
        return 0
    fi
 
-   IMAGE_BASENAME="${@d.getVar('IMAGE_BASENAME')}"
-   FLATPAK_IMAGE_PATTERN="${@d.getVar('FLATPAK_IMAGE_PATTERN')}"
+   IMAGE_BASENAME="${@d.getVar('IMAGE_BASENAME', False)}"
+   FLATPAK_IMAGE_PATTERN="${@d.getVar('FLATPAK_IMAGE_PATTERN', False)}"
 
    echo "Flatpak repository exporting:"
    echo " * IMAGE_BASENAME: $IMAGE_BASENAME"
-   echo " * IMAGE_NAME:     ${@d.getVar('IMAGE_NAME')}"
+   echo " * IMAGE_NAME:     ${@d.getVar('IMAGE_NAME', False)}"
 
    # Bail out if this looks like an initramfs image.
    case $IMAGE_BASENAME in
@@ -170,18 +170,18 @@ do_flatpakexport () {
        *)                 FLATPAK_RUNTIME=runtime;;
    esac
 
-   FLATPAKBASE="${@d.getVar('FLATPAKBASE')}"
-   FLATPAK_TOPDIR="${@d.getVar('FLATPAK_TOPDIR')}"
-   FLATPAK_TMPDIR="${@d.getVar('FLATPAK_TMPDIR')}"
-   FLATPAK_ROOTFS="${@d.getVar('FLATPAK_ROOTFS')}"
-   FLATPAK_ARCH="${@d.getVar('FLATPAK_ARCH')}"
-   FLATPAK_GPGDIR="${@d.getVar('FLATPAK_GPGDIR')}"
-   FLATPAK_GPGID="${@d.getVar('FLATPAK_GPGID')}"
-   FLATPAK_REPO="${@d.getVar('FLATPAK_REPO')}"
-   FLATPAK_DISTRO="${@d.getVar('FLATPAK_DISTRO')}"
-   FLATPAK_RUNTIME_IMAGE="${@d.getVar('FLATPAK_RUNTIME_IMAGE')}"
-   FLATPAK_CURRENT="${@d.getVar('FLATPAK_CURRENT')}"
-   FLATPAK_VERSION="${@d.getVar('FLATPAK_VERSION')}"
+   FLATPAKBASE="${@d.getVar('FLATPAKBASE', False)}"
+   FLATPAK_TOPDIR="${@d.getVar('FLATPAK_TOPDIR', False)}"
+   FLATPAK_TMPDIR="${@d.getVar('FLATPAK_TMPDIR', False)}"
+   FLATPAK_ROOTFS="${@d.getVar('FLATPAK_ROOTFS', False)}"
+   FLATPAK_ARCH="${@d.getVar('FLATPAK_ARCH', False)}"
+   FLATPAK_GPGDIR="${@d.getVar('FLATPAK_GPGDIR', False)}"
+   FLATPAK_GPGID="${@d.getVar('FLATPAK_GPGID', False)}"
+   FLATPAK_REPO="${@d.getVar('FLATPAK_REPO', False)}"
+   FLATPAK_DISTRO="${@d.getVar('FLATPAK_DISTRO', False)}"
+   FLATPAK_RUNTIME_IMAGE="${@d.getVar('FLATPAK_RUNTIME_IMAGE', False)}"
+   FLATPAK_CURRENT="${@d.getVar('FLATPAK_CURRENT', False)}"
+   FLATPAK_VERSION="${@d.getVar('FLATPAK_VERSION', False)}"
 
    VERSION=$(cat $FLATPAK_ROOTFS/etc/version)
 

--- a/classes/flatpak-variables.bbclass
+++ b/classes/flatpak-variables.bbclass
@@ -14,7 +14,7 @@ FLATPAK_EXPORT ?= "${TOPDIR}/${IMAGE_BASENAME}.flatpak"
 # This is where our GPG keyring is generated/located and the default
 # key ID we use to sign (commits in) the repository.
 FLATPAK_GPGDIR ?= "${TOPDIR}/gpg"
-FLATPAK_GPGID  ?= "${@(d.getVar('DISTRO') or \
+FLATPAK_GPGID  ?= "${@(d.getVar('DISTRO', False) or \
                          'unknown').replace(' ', '_') + '-signing@key'}"
 
 # By default we publish two 'version' branches in our flatpak repositories:
@@ -24,7 +24,7 @@ FLATPAK_GPGID  ?= "${@(d.getVar('DISTRO') or \
 # not just image builds. The third one, build, is only available in image
 # builds.
 FLATPAK_CURRENT ?= "current"
-FLATPAK_VERSION ?= "${@(d.getVar('DISTRO_VERSION') or \
+FLATPAK_VERSION ?= "${@(d.getVar('DISTRO_VERSION', False) or \
                                                   0.0).split('+snapshot')[0]}"
 FLATPAK_BUILD    = "${BUILD_ID}"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,10 +17,10 @@ SUPPORTED_RECIPES_append = " \
 
 # Pick up our passwd and group fragments for remotes if we have any
 # pre-declared ones.
-USERADD_UID_TABLES += "${@ d.getVar('TOPDIR') + '/conf/flatpak-passwd' \
-                             if d.getVar('FLATPAK_APP_REPOS') else ''}"
-USERADD_GID_TABLES += "${@ d.getVar('TOPDIR') + '/conf/flatpak-group' \
-                             if d.getVar('FLATPAK_APP_REPOS') else ''}"
+USERADD_UID_TABLES += "${@ d.getVar('TOPDIR', False) + '/conf/flatpak-passwd' \
+                             if d.getVar('FLATPAK_APP_REPOS', False) else ''}"
+USERADD_GID_TABLES += "${@ d.getVar('TOPDIR', False) + '/conf/flatpak-group' \
+                             if d.getVar('FLATPAK_APP_REPOS', False) else ''}"
 
 # Hmm... this does not seem to have the desired effect reliably from here.
 # This should be in our distro.conf... 2.4.x is GPLv3.

--- a/recipes-flatpak/flatpak-image-runtime/flatpak-image-runtime_git.bb
+++ b/recipes-flatpak/flatpak-image-runtime/flatpak-image-runtime_git.bb
@@ -39,10 +39,10 @@ EXTRA_OECONF += " \
 "
 
 do_configure_prepend () {
-    FLATPAK_ROOTFS="${@d.getVar('FLATPAK_ROOTFS')}"
-    FLATPAK_CURRENT="${@d.getVar('FLATPAK_CURRENT')}"
-    FLATPAK_ARCH="${@d.getVar('FLATPAK_ARCH')}"
-    FLATPAK_VERSION="${@d.getVar('FLATPAK_VERSION')}"
+    FLATPAK_ROOTFS="${@d.getVar('FLATPAK_ROOTFS', False)}"
+    FLATPAK_CURRENT="${@d.getVar('FLATPAK_CURRENT', False)}"
+    FLATPAK_ARCH="${@d.getVar('FLATPAK_ARCH', False)}"
+    FLATPAK_VERSION="${@d.getVar('FLATPAK_VERSION', False)}"
 
     case $FLATPAK_ARCH in
         intel*64) arch=x86_64;;

--- a/recipes-flatpak/flatpak-predefined-repos/flatpak-predefined-repos.bb
+++ b/recipes-flatpak/flatpak-predefined-repos/flatpak-predefined-repos.bb
@@ -21,7 +21,7 @@ inherit autotools flatpak-variables
 # Turn the space-separated repo name list into a comma-separated one and
 # pass it to configure.
 EXTRA_OECONF += " \
-    --with-repos=${@','.join(d.getVar('FLATPAK_APP_REPOS').split())} \
+    --with-repos=${@','.join(d.getVar('FLATPAK_APP_REPOS', False).split())} \
 "
 
 # We can't just blindly inherit useradd. It has a parse-time check and
@@ -32,12 +32,12 @@ EXTRA_OECONF += " \
 # Therefore, we inherit useradd conditionally only if the set of repos
 # is not empty to avoid a parse-time failure.
 #
-inherit ${@'useradd' if d.getVar('FLATPAK_APP_REPOS') else ''}
+inherit ${@'useradd' if d.getVar('FLATPAK_APP_REPOS', False) else ''}
 
 # Ask for the creation of the necessary repo users/groups (turn the
 # space-separated list into a semi-colon-separated one).
 USERADD_PACKAGES = "${PN}"
-USERADD_PARAM_${PN} = "${@';'.join(d.getVar('FLATPAK_APP_REPOS').split())}"
+USERADD_PARAM_${PN} = "${@';'.join(d.getVar('FLATPAK_APP_REPOS', False).split())}"
 
 
 FILES_${PN} = " \
@@ -47,8 +47,8 @@ FILES_${PN} = " \
 do_configure_prepend () {
     local _build _r
 
-    _build="${@d.getVar('TOPDIR')}"
-    FLATPAK_APP_REPOS="${@d.getVar('FLATPAK_APP_REPOS')}"
+    _build="${@d.getVar('TOPDIR', False)}"
+    FLATPAK_APP_REPOS="${@d.getVar('FLATPAK_APP_REPOS', False)}"
     if [ -z "$FLATPAK_APP_REPOS" ]; then
         return 0
     fi


### PR DESCRIPTION
getVar() now requires the expand parameter:

http://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#migration-2.1-expand-parameter-to-getvar-and-getvarflag-now-mandatory