### PR TITLE
gpgme: Fix parsing error in pyro (2.2)

### DIFF
--- a/recipes-support/gnupg/gnupg_1.%.bbappend
+++ b/recipes-support/gnupg/gnupg_1.%.bbappend
@@ -21,5 +21,4 @@ do_configure_prepend () {
 RDEPENDS_${PN}_remove = "gpgv"
 RDEPENDS_${PN}_class-target = "gpgv"
 
-BBCLASSEXTEND = "native"
-
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-support/gpgme/gpgme_%.bbappend
+++ b/recipes-support/gpgme/gpgme_%.bbappend
@@ -4,5 +4,3 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 GPGME_BACKENDS ?= "gnupg"
 
 RDEPENDS_${PN} += "${GPGME_BACKENDS}"
-
-BBCLASSEXTEND = "native"


### PR DESCRIPTION
In pyro, BBCLASSEXTEND = "native nativesdk" is already defined.

[ERROR]
Missing or unbuildable dependency chain was: ['genivi-dev-platform',
'nativesdk-packagegroup-sdk-host', 'nativesdk-dnf', 'nativesdk-librepo',
'nativesdk-gpgme']

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>